### PR TITLE
Fixed wrongful event handling

### DIFF
--- a/src/com/m0pt0pmatt/railduplicationfix/RailDuplicationFixPlugin.java
+++ b/src/com/m0pt0pmatt/railduplicationfix/RailDuplicationFixPlugin.java
@@ -7,6 +7,8 @@ import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockPistonEvent;
+import org.bukkit.event.block.BlockPistonExtendEvent;
+import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 public class RailDuplicationFixPlugin extends JavaPlugin implements Listener{
@@ -16,11 +18,22 @@ public class RailDuplicationFixPlugin extends JavaPlugin implements Listener{
 	}
 	
 	@EventHandler
+	public void onPistonExtend(BlockPistonExtendEvent event) {
+		onPistonEvent(event);
+	}
+	
+	@EventHandler
+	public void onPistonExtend(BlockPistonRetractEvent event) {
+		onPistonEvent(event);
+	}
+	
+	
 	public void onPistonEvent(BlockPistonEvent event){
-		
+		System.out.println("event!");
 		if (!event.isSticky()){
 			return;
 		}
+		//if ()
 		
 		int x = 0;
 		int y = 0;
@@ -48,13 +61,21 @@ public class RailDuplicationFixPlugin extends JavaPlugin implements Listener{
 			break;
 		}
 		
+		if (event instanceof BlockPistonRetractEvent) {
+			//because it's already extended, we need to look 2 in the right direction:wq
+			
+			x *= 2;
+			y *= 2;
+			z *= 2;
+		}
+		
 		Location location = event.getBlock().getLocation();
 		Block rail = event.getBlock().getWorld().getBlockAt(location.getBlockX() + x, location.getBlockY() + y, location.getBlockZ() + z);
 		
 		if (rail.getType().equals(Material.POWERED_RAIL) 
 				|| rail.getType().equals(Material.ACTIVATOR_RAIL) 
 				|| rail.getType().equals(Material.DETECTOR_RAIL)){
-			
+			System.out.println("Canceling event!");
 			event.setCancelled(true);
 			
 		}

--- a/src/com/m0pt0pmatt/railduplicationfix/RailDuplicationFixPlugin.java
+++ b/src/com/m0pt0pmatt/railduplicationfix/RailDuplicationFixPlugin.java
@@ -29,7 +29,6 @@ public class RailDuplicationFixPlugin extends JavaPlugin implements Listener{
 	
 	
 	public void onPistonEvent(BlockPistonEvent event){
-		System.out.println("event!");
 		if (!event.isSticky()){
 			return;
 		}
@@ -75,7 +74,6 @@ public class RailDuplicationFixPlugin extends JavaPlugin implements Listener{
 		if (rail.getType().equals(Material.POWERED_RAIL) 
 				|| rail.getType().equals(Material.ACTIVATOR_RAIL) 
 				|| rail.getType().equals(Material.DETECTOR_RAIL)){
-			System.out.println("Canceling event!");
 			event.setCancelled(true);
 			
 		}


### PR DESCRIPTION
I updated this so that it works on both the piston extend and retract event instead of the parent piston event. You cannot register for this handler because it doesn't exist.